### PR TITLE
상세 프로젝트에서도 전체 프로젝트 목록이 보이도록 구현

### DIFF
--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -23,6 +23,7 @@ function DetailProject() {
   const { id } = useParams();
   const [project, setProject] = useState('');
   const [allProject, setAllProject] = useState(null);
+  const [asideProject, setAsideProject] = useState(null);
   const devAvatar = useSelector((state) => state.fetchData.devAvatar);
   const [importLoading, setImportLoading] = useState(true);
 
@@ -38,6 +39,19 @@ function DetailProject() {
   const [inputDescription, setInputDescription] = useState([]);
   const [inputSourceCode, setInputSourceCode] = useState(null);
   const [beforeThumbnail, setBeforeThumbnail] = useState(null);
+
+  // * 모든 프로젝트 필터로 10개씩만 보여주기
+  const asideFilter = () => {
+    const filterProject = 10;
+    const startIndex = filterProject - 1;
+
+    const filterData = allProject.filter(
+      (item, index) => (index) =>
+        startIndex && index <= startIndex + filterProject
+    );
+    setAsideProject(filterData);
+    setLoading(false);
+  };
 
   // * 프로젝트 내용 불러오기 #2
   const info = async () => {
@@ -68,7 +82,7 @@ function DetailProject() {
 
     // 나머지 전체 프로젝트
     setAllProject(data);
-    setLoading(false);
+    asideFilter();
   };
 
   // * 페이지 로딩이 완료되면 최초 실행, 프로젝트 수정이 완료되면 실행 #1
@@ -188,7 +202,7 @@ function DetailProject() {
             <article className={styles.article}>
               <aside className={styles.aside}>
                 <ul>
-                  {allProject.map((value, index) => (
+                  {asideProject.map((value, index) => (
                     <li key={index}>
                       <Link
                         className={value._id === id ? styles.active : null}
@@ -199,6 +213,17 @@ function DetailProject() {
                       </Link>
                     </li>
                   ))}
+                  {/* {allProject.map((value, index) => (
+                    <li key={index}>
+                      <Link
+                        className={value._id === id ? styles.active : null}
+                        onClick={() => setLoading(true)}
+                        to={`/project/${value._id}`}
+                      >
+                        {value.title}
+                      </Link>
+                    </li>
+                  ))} */}
                 </ul>
               </aside>
               {edit ? (

--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -2,9 +2,8 @@
 import Header from '../partials/Header';
 import Footer from '../partials/Footer';
 import Loading from '../config/Loading';
-
 // Function
-import { server, uploadFile } from './Home';
+import { downloadFiles, uploadFile } from './Home';
 import extendStyles from '../../styles/screen/css/Upload.module.css';
 import styles from '../../styles/screen/css/DetailProject.module.css';
 import { initial } from '../../_redux/_reducer/InfoSlice';
@@ -23,6 +22,7 @@ function DetailProject() {
   const [loading, setLoading] = useState(true);
   const { id } = useParams();
   const [project, setProject] = useState('');
+  const [allProject, setAllProject] = useState(null);
   const devAvatar = useSelector((state) => state.fetchData.devAvatar);
   const [importLoading, setImportLoading] = useState(true);
 
@@ -41,9 +41,10 @@ function DetailProject() {
 
   // * 프로젝트 내용 불러오기 #2
   const info = async () => {
-    const data = await (await server.get(`/project/${id}`)).data;
-    setProject(data);
-    setLoading(false);
+    const data = await (await downloadFiles('/')).data;
+    // 현재 접근한 프로젝트 필터링
+    const filterData = data.filter((value) => value._id === id)[0];
+    setProject(filterData);
     // 기존값 설정
     const {
       url,
@@ -64,6 +65,10 @@ function DetailProject() {
     setInputDescription(description);
     setBeforeThumbnail(thumbnail);
     setInputSourceCode(sourceCode);
+
+    // 나머지 전체 프로젝트
+    setAllProject(data);
+    setLoading(false);
   };
 
   // * 페이지 로딩이 완료되면 최초 실행, 프로젝트 수정이 완료되면 실행 #1
@@ -71,7 +76,7 @@ function DetailProject() {
     if (!edit) {
       info();
     }
-  }, [initPage, edit]);
+  }, [initPage, edit, loading]);
 
   // * 해당 페이지에서 새로고침할 경우, 개발자 이미지 데이터가 적용되면(App.jsx) 로딩 완료
   useEffect(() => {
@@ -181,6 +186,21 @@ function DetailProject() {
         <>
           <main>
             <article className={styles.article}>
+              <aside className={styles.aside}>
+                <ul>
+                  {allProject.map((value, index) => (
+                    <li key={index}>
+                      <Link
+                        className={value._id === id ? styles.active : null}
+                        onClick={() => setLoading(true)}
+                        to={`/project/${value._id}`}
+                      >
+                        {value.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </aside>
               {edit ? (
                 importLoading ? null : (
                   <>
@@ -311,7 +331,9 @@ function DetailProject() {
                       <button className={styles.editBtn} onClick={onClick}>
                         수정하기
                       </button>
-                    ) : null}
+                    ) : (
+                      <span className={styles.empty}></span>
+                    )}
                   </div>
                   <Link to={project.url} target="_blank">
                     <picture className={styles.picture}>

--- a/client/src/styles/config/scss/_variables.scss
+++ b/client/src/styles/config/scss/_variables.scss
@@ -45,3 +45,4 @@
 }
 
 $headerHeight: 80px;
+$themeColor: #ecdad1;

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -1,8 +1,40 @@
+@import '../../config//scss//variables';
+
 // ^ 컴포넌트
 .article {
   display: grid;
   place-content: center;
   gap: 20px;
+}
+
+// * Aside 다른 프로젝트
+.aside {
+  position: absolute;
+  left: 0;
+  top: calc(100vh / 2);
+  transform: translateY(-50%);
+  padding: 20px;
+
+  > ul {
+    li {
+      margin: 10px 0;
+      &:hover {
+        text-decoration: underline;
+      }
+
+      a {
+        display: block;
+      }
+
+      // 현재 프로젝트
+      .active {
+        color: $themeColor;
+        border-left: 5px solid #000;
+        text-indent: 10px;
+        text-shadow: 0.5px 0.5px 1px rgba(0, 0, 0, 0.5);
+      }
+    }
+  }
 }
 
 // ^ 프로젝트 상단 정보 (개발자, 타이틀, 수정하기)

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -9,11 +9,10 @@
 
 // * Aside 다른 프로젝트
 .aside {
-  position: absolute;
-  left: 0;
-  top: calc(100vh / 2);
+  position: fixed;
+  left: 50px;
+  top: 50%;
   transform: translateY(-50%);
-  padding: 20px;
 
   > ul {
     li {

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -13,6 +13,7 @@
   left: 50px;
   top: 50%;
   transform: translateY(-50%);
+  // TODO: 1, 2, 3 ... 생성으로 프로젝트가 많아지면 생기는 현상 해결
 
   > ul {
     li {

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -10,19 +10,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
 }
 
-// 수정하기 버튼
-.editBtn {
-  float: right;
+// 개발자 이미지
+.devImgWrap {
+  float: left;
 }
-
-// 프로젝트 이미지
-.picture {
-  img {
-    max-width: 1200px;
-    object-fit: cover;
-  }
+.devImg {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
 }
 
 // 타이틀
@@ -35,14 +33,23 @@
   }
 }
 
-// ^ 개발자 이미지
-.devImgWrap {
-  float: left;
+// 수정하기 버튼
+.editBtn {
+  float: right;
 }
-.devImg {
+// 비로그인시 차지 영역
+.empty {
   width: 100px;
-  height: 100px;
-  border-radius: 50%;
+}
+
+// ^ 프로젝트 이미지
+.picture {
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 50px;
+  img {
+    max-width: 1200px;
+    object-fit: cover;
+  }
 }
 
 // 프로그램 언어 및 도구
@@ -69,6 +76,7 @@
 // ^ 소스코드, API 등등
 .info {
   display: flex;
+  gap: 20px;
 }
 
 // ^ 소스코드


### PR DESCRIPTION
1. 상세 프로젝트 컴포넌트에서도 전체 프로젝트 목록 확인이 가능하도록 구현
2. 위치는 좌측 중앙에 고정 방식으로 스타일링함
3. 프로젝트 개수는 10개만 보이도록 설정했으며, 추후에는 1, 2, 3 페이지와 같이 나누어서 표시할 예정