### PR TITLE
SourceCode -> Url 변경 및 REST API 규칙화

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -23,7 +23,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-*.module.css
-*.css
-
 Dockerfile

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,7 +41,7 @@ const router = createBrowserRouter([
     element: <Upload />,
   },
   {
-    path: '/project/:id',
+    path: '/projects/:id',
     element: <DetailProject />,
   },
 ]);

--- a/client/src/_redux/_reducer/fetchSlice.jsx
+++ b/client/src/_redux/_reducer/fetchSlice.jsx
@@ -5,7 +5,7 @@ export const getAdminAvatar = createAsyncThunk(
   'admin/getAdminAvatar',
   async (thunkAPI) => {
     try {
-      const res = await server.get('/avatarImg');
+      const res = await server.get('/avatarimg');
       return res.data;
     } catch (err) {
       return thunkAPI.rejectWithValue(err);

--- a/client/src/components/mixins/Project.jsx
+++ b/client/src/components/mixins/Project.jsx
@@ -1,12 +1,12 @@
 // Function
-import styles from "../../styles/mixins/css/Projects.module.css";
-import { server, uploadFile } from "../screen/Home";
-import { initial } from "../../_redux/_reducer/InfoSlice";
+import styles from '../../styles/mixins/css/Projects.module.css';
+import { server, uploadFile } from '../screen/Home';
+import { initial } from '../../_redux/_reducer/InfoSlice';
 
 // Package
-import { Link } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
-import { useState } from "react";
+import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { useState } from 'react';
 
 function Project({ id, logged, date, title, developer, thumbnail, language }) {
   // React 세팅
@@ -14,7 +14,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
   const [inputDate, setInputDate] = useState(date);
   const [inputDeveloper, setInputDeveloper] = useState(developer);
   const [inputTitle, setInputTitle] = useState(title);
-  const [inputThumbnail, setInputThumbnail] = useState("");
+  const [inputThumbnail, setInputThumbnail] = useState('');
   const [thumbnailPreview, setThumbnailPreview] = useState(
     `${process.env.REACT_APP_SERVER}/image/${thumbnail}`
   );
@@ -28,9 +28,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
   // 프로젝트 삭제
   const onClick = async () => {
     // 서버에 삭제 요청
-    const { status } = await server.post(`/project/${id}/delete`, {
-      thumbnail,
-    });
+    const { status } = await server.delete(`/project/${id}/${thumbnail}`);
     if (status === 200) {
       // 프로젝트 변경으로 인해 재 렌더링 요청
       dispatch(initial(false));
@@ -41,15 +39,15 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
     e.preventDefault();
     // 수정사항 파일 전송용 formData 생성
     const formData = new FormData();
-    formData.append("date", inputDate);
-    formData.append("title", inputTitle);
-    formData.append("developer", inputDeveloper);
-    formData.append("thumbnail", inputThumbnail);
-    formData.append("language", inputLanguage);
-    formData.append("beforeId", id);
-    formData.append("beforeImg", thumbnail);
+    formData.append('date', inputDate);
+    formData.append('title', inputTitle);
+    formData.append('developer', inputDeveloper);
+    formData.append('thumbnail', inputThumbnail);
+    formData.append('language', inputLanguage);
+    formData.append('beforeId', id);
+    formData.append('beforeImg', thumbnail);
     // 프로젝트 업데이트 요청
-    await uploadFile.post(`/project/${id}/edit`, formData);
+    await uploadFile.put(`/project/${id}/edit`, formData);
     // 프로젝트 변경으로 인해 재 렌더링 요청
     dispatch(initial(false));
     // 수정하기 종료
@@ -60,17 +58,17 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
   const onChange = (e) => {
     const { name, value } = e.target;
     switch (name) {
-      case "date":
+      case 'date':
         setInputDate(value);
         break;
-      case "developer":
-        const arrDeveloperValue = value.split(",").map((item) => item.trim());
+      case 'developer':
+        const arrDeveloperValue = value.split(',').map((item) => item.trim());
         setInputDeveloper(arrDeveloperValue);
         break;
-      case "title":
+      case 'title':
         setInputTitle(value);
         break;
-      case "thumbnail":
+      case 'thumbnail':
         const file = e.target.files[0];
         file.date = new Date();
         // 업로드할 이미지 파일
@@ -86,7 +84,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
             resolve();
           };
         });
-      case "language":
+      case 'language':
         setInputLanguage(value);
         break;
       default:

--- a/client/src/components/mixins/Project.jsx
+++ b/client/src/components/mixins/Project.jsx
@@ -28,7 +28,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
   // 프로젝트 삭제
   const onClick = async () => {
     // 서버에 삭제 요청
-    const { status } = await server.delete(`/project/${id}/${thumbnail}`);
+    const { status } = await server.delete(`/projects/${id}/${thumbnail}`);
     if (status === 200) {
       // 프로젝트 변경으로 인해 재 렌더링 요청
       dispatch(initial(false));
@@ -47,7 +47,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
     formData.append('beforeId', id);
     formData.append('beforeImg', thumbnail);
     // 프로젝트 업데이트 요청
-    await uploadFile.put(`/project/${id}/edit`, formData);
+    await uploadFile.put(`/projects/${id}/edit`, formData);
     // 프로젝트 변경으로 인해 재 렌더링 요청
     dispatch(initial(false));
     // 수정하기 종료
@@ -216,7 +216,7 @@ function Project({ id, logged, date, title, developer, thumbnail, language }) {
             })}
           </small>
           {/* 프로젝트 제목, 이미지 */}
-          <Link to={`/project/${id}`}>
+          <Link to={`/projects/${id}`}>
             <h3 className={styles.title}>{title}</h3>
             <div className={styles.imgWrap}>
               <img

--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -3,7 +3,7 @@ import Header from '../partials/Header';
 import Footer from '../partials/Footer';
 import Loading from '../config/Loading';
 // Function
-import { downloadFiles, uploadFile } from './Home';
+import { downloadFiles, server, uploadFile } from './Home';
 import extendStyles from '../../styles/screen/css/Upload.module.css';
 import styles from '../../styles/screen/css/DetailProject.module.css';
 import { initial } from '../../_redux/_reducer/InfoSlice';
@@ -37,7 +37,6 @@ function DetailProject() {
   const [thumbnailPreview, setThumbnailPreview] = useState(null);
   const [inputLanguage, setInputLanguage] = useState([]);
   const [inputDescription, setInputDescription] = useState([]);
-  const [inputSourceCode, setInputSourceCode] = useState(null);
   const [beforeThumbnail, setBeforeThumbnail] = useState(null);
 
   // * 모든 프로젝트 필터로 10개씩만 보여주기
@@ -68,6 +67,7 @@ function DetailProject() {
     setInputDate(date);
     setInputTitle(title);
     setDeveloperSelect(developer);
+    setInputThumbnail(thumbnail);
     setThumbnailPreview(`${process.env.REACT_APP_SERVER}/image/${thumbnail}`);
     setInputLanguage(language);
     setInputDescription(description);
@@ -112,6 +112,17 @@ function DetailProject() {
   // ^ 수정하기
   const onClick = () => {
     edit ? setEdit(false) : setEdit(true);
+  };
+
+  // ^ 삭제하기
+  const deleteProject = async () => {
+    // 서버에 삭제 요청
+    const { status } = await server.delete(`/project/${id}/${inputThumbnail}`);
+    if (status === 200) {
+      // 프로젝트 변경으로 인해 재 렌더링 요청
+      dispatch(initial(false));
+      navigate('/');
+    }
   };
 
   // ^ 데이터 저장
@@ -173,7 +184,7 @@ function DetailProject() {
     formData.append('beforeThumbnail', beforeThumbnail);
 
     // 수정 요청
-    await uploadFile.post(`/project/${id}/edit`, formData);
+    await uploadFile.put(`/project/${id}/edit`, formData);
 
     // 재렌더링 및 수정하기 종료
     dispatch(initial(false));
@@ -207,17 +218,6 @@ function DetailProject() {
                       </Link>
                     </li>
                   ))}
-                  {/* {allProject.map((value, index) => (
-                    <li key={index}>
-                      <Link
-                        className={value._id === id ? styles.active : null}
-                        onClick={() => setLoading(true)}
-                        to={`/project/${value._id}`}
-                      >
-                        {value.title}
-                      </Link>
-                    </li>
-                  ))} */}
                 </ul>
               </aside>
               {edit ? (
@@ -347,9 +347,10 @@ function DetailProject() {
                       <small>{project.date.substring(0, 10)}</small>
                     </div>
                     {logged ? (
-                      <button className={styles.editBtn} onClick={onClick}>
-                        수정하기
-                      </button>
+                      <div className={styles.edit}>
+                        <button onClick={onClick}>수정하기</button>
+                        <button onClick={deleteProject}>삭제하기</button>
+                      </div>
                     ) : (
                       <span className={styles.empty}></span>
                     )}

--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -1,17 +1,17 @@
 // Components
-import Header from "../partials/Header";
-import Footer from "../partials/Footer";
-import Loading from "../config/Loading";
+import Header from '../partials/Header';
+import Footer from '../partials/Footer';
+import Loading from '../config/Loading';
 // Function
-import { downloadFiles, uploadFile } from "./Home";
-import extendStyles from "../../styles/screen/css/Upload.module.css";
-import styles from "../../styles/screen/css/DetailProject.module.css";
-import { initial } from "../../_redux/_reducer/InfoSlice";
+import { downloadFiles, uploadFile } from './Home';
+import extendStyles from '../../styles/screen/css/Upload.module.css';
+import styles from '../../styles/screen/css/DetailProject.module.css';
+import { initial } from '../../_redux/_reducer/InfoSlice';
 
 // Package
-import { Link, useNavigate, useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 function DetailProject() {
   const dispatch = useDispatch();
@@ -21,7 +21,7 @@ function DetailProject() {
   const initPage = useSelector((state) => state.info.initial);
   const [loading, setLoading] = useState(true);
   const { id } = useParams();
-  const [project, setProject] = useState("");
+  const [project, setProject] = useState('');
   const [allProject, setAllProject] = useState(null);
   const [asideProject, setAsideProject] = useState(null);
   const devAvatar = useSelector((state) => state.fetchData.devAvatar);
@@ -55,23 +55,15 @@ function DetailProject() {
 
   // * 프로젝트 내용 불러오기 #2
   const info = async () => {
-    const data = await (await downloadFiles("/")).data;
+    const data = await (await downloadFiles('/')).data;
     // 현재 접근한 프로젝트 필터링
     const filterData = data.filter((value) => value._id === id)[0];
     setProject(filterData);
     // 나머지 전체 프로젝트
     setAllProject(data);
     // 기존값 설정
-    const {
-      url,
-      date,
-      title,
-      developer,
-      thumbnail,
-      language,
-      description,
-      sourceCode,
-    } = data;
+    const { url, date, title, developer, thumbnail, language, description } =
+      filterData;
     setInputUrl(url);
     setInputDate(date);
     setInputTitle(title);
@@ -80,7 +72,6 @@ function DetailProject() {
     setInputLanguage(language);
     setInputDescription(description);
     setBeforeThumbnail(thumbnail);
-    setInputSourceCode(sourceCode);
   };
 
   // * 프로젝트가 설정되면 Aside 필터 실행
@@ -127,16 +118,16 @@ function DetailProject() {
   const onChange = (e) => {
     const { name, value } = e.target;
     switch (name) {
-      case "url":
+      case 'url':
         setInputUrl(value);
         return;
-      case "date":
+      case 'date':
         setInputDate(value);
         return;
-      case "title":
+      case 'title':
         setInputTitle(value);
         return;
-      case "thumbnail":
+      case 'thumbnail':
         const file = e.target.files[0];
         file.date = new Date();
         // 업로드할 이미지 파일
@@ -154,14 +145,11 @@ function DetailProject() {
             resolve();
           };
         });
-      case "language":
+      case 'language':
         setInputLanguage(value);
         return;
-      case "description":
+      case 'description':
         setInputDescription(value);
-        return;
-      case "sourceCode":
-        setInputSourceCode(value);
         return;
       default:
         break;
@@ -174,16 +162,15 @@ function DetailProject() {
 
     // Form 생성
     const formData = new FormData();
-    formData.append("url", inputUrl);
-    formData.append("date", inputDate);
-    formData.append("title", inputTitle);
-    formData.append("developer", developerSelect);
-    formData.append("thumbnail", inputThumbnail);
-    formData.append("language", inputLanguage);
-    formData.append("description", inputDescription);
-    formData.append("sourceCode", inputSourceCode);
-    formData.append("beforeId", id);
-    formData.append("beforeThumbnail", beforeThumbnail);
+    formData.append('url', inputUrl);
+    formData.append('date', inputDate);
+    formData.append('title', inputTitle);
+    formData.append('developer', developerSelect);
+    formData.append('thumbnail', inputThumbnail);
+    formData.append('language', inputLanguage);
+    formData.append('description', inputDescription);
+    formData.append('beforeId', id);
+    formData.append('beforeThumbnail', beforeThumbnail);
 
     // 수정 요청
     await uploadFile.post(`/project/${id}/edit`, formData);
@@ -242,6 +229,15 @@ function DetailProject() {
                       className={extendStyles.form}
                     >
                       <label>
+                        <p className={styles.url}>프로젝트 주소</p>
+                        <input
+                          name="url"
+                          type="url"
+                          onChange={onChange}
+                          value={inputUrl}
+                        />
+                      </label>
+                      <label>
                         <p className={extendStyles.name}>날짜</p>
                         <input
                           name="date"
@@ -282,7 +278,7 @@ function DetailProject() {
                                   src={value.img}
                                   alt=""
                                   crossOrigin="anonymous"
-                                />{" "}
+                                />{' '}
                                 {value.username}
                               </li>
                             ))}
@@ -319,15 +315,6 @@ function DetailProject() {
                           value={inputDescription}
                           onChange={onChange}
                           placeholder="본문"
-                        />
-                      </label>
-                      <label>
-                        <input
-                          name="sourceCode"
-                          type="url"
-                          value={inputSourceCode}
-                          onChange={onChange}
-                          placeholder="소스코드 주소"
                         />
                       </label>
                       <button type="submit">수정</button>
@@ -368,12 +355,18 @@ function DetailProject() {
                     )}
                   </div>
                   <Link to={project.url} target="_blank">
-                    <picture className={styles.picture}>
-                      <img
-                        src={`${process.env.REACT_APP_SERVER}/image/${project.thumbnail}`}
-                        alt="이미지"
-                      />
-                    </picture>
+                    <figure>
+                      <picture className={styles.picture}>
+                        <img
+                          src={`${process.env.REACT_APP_SERVER}/image/${project.thumbnail}`}
+                          alt="이미지"
+                        />
+                      </picture>
+                      <figcaption className={styles.info}>
+                        <i className={styles.url}></i> {project.title} 홈페이지
+                        이동하기
+                      </figcaption>
+                    </figure>
                   </Link>
                   <div className={styles.language}>
                     {!project
@@ -396,15 +389,6 @@ function DetailProject() {
                   <pre className={styles.description}>
                     {project.description}
                   </pre>
-                  <div className={styles.info}>
-                    <Link
-                      className={styles.sourceCode}
-                      to={project.sourceCode}
-                      target="_blank"
-                    >
-                      소스코드
-                    </Link>
-                  </div>
                 </>
               )}
               <button className={styles.prevBtn} onClick={prevPage}></button>

--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -182,7 +182,7 @@ function DetailProject() {
 
   // ^ 이전 페이지로 이동
   const prevPage = () => {
-    navigate(-1);
+    navigate('/');
   };
 
   return (

--- a/client/src/components/screen/DetailProject.jsx
+++ b/client/src/components/screen/DetailProject.jsx
@@ -117,7 +117,7 @@ function DetailProject() {
   // ^ 삭제하기
   const deleteProject = async () => {
     // 서버에 삭제 요청
-    const { status } = await server.delete(`/project/${id}/${inputThumbnail}`);
+    const { status } = await server.delete(`/projects/${id}/${inputThumbnail}`);
     if (status === 200) {
       // 프로젝트 변경으로 인해 재 렌더링 요청
       dispatch(initial(false));
@@ -184,7 +184,7 @@ function DetailProject() {
     formData.append('beforeThumbnail', beforeThumbnail);
 
     // 수정 요청
-    await uploadFile.put(`/project/${id}/edit`, formData);
+    await uploadFile.put(`/projects/${id}/edit`, formData);
 
     // 재렌더링 및 수정하기 종료
     dispatch(initial(false));
@@ -212,7 +212,7 @@ function DetailProject() {
                       <Link
                         className={value._id === id ? styles.active : null}
                         onClick={() => setLoading(true)}
-                        to={`/project/${value._id}`}
+                        to={`/projects/${value._id}`}
                       >
                         {value.title}
                       </Link>

--- a/client/src/components/screen/Upload.jsx
+++ b/client/src/components/screen/Upload.jsx
@@ -21,6 +21,7 @@ function Upload() {
   const [loading, setLoading] = useState(true);
   const [admin, setAdmin] = useState(null); //img, username
   const logged = useSelector((state) => state.info.logged);
+  const devAvatar = useSelector((state) => state.fetchData.devAvatar);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   // input
@@ -39,11 +40,10 @@ function Upload() {
 
   // * 개발자 이미지 요청
   const adminImg = async () => {
-    const { data } = await server.get('/avatarImg');
-    if (!data) {
+    if (!devAvatar) {
       return navigate('/');
     }
-    setAdmin(data);
+    setAdmin(devAvatar);
     setLoading(false);
   };
 

--- a/client/src/components/screen/Upload.jsx
+++ b/client/src/components/screen/Upload.jsx
@@ -36,7 +36,6 @@ function Upload() {
   const [thumbnailPreview, setThumbnailPreview] = useState('');
   const [inputLanguage, setInputLanguage] = useState([]);
   const [inputDescription, setInputDescription] = useState();
-  const [inputSourceCode, setInputSourceCode] = useState('');
 
   // * 개발자 이미지 요청
   const adminImg = async () => {
@@ -72,14 +71,13 @@ function Upload() {
     formData.append('thumbnail', inputThumbnail);
     formData.append('language', inputLanguage);
     formData.append('description', inputDescription);
-    formData.append('sourceCode', inputSourceCode);
     // Project 생성 요청
     const { status, data } = await uploadFile.post('/upload', formData);
     if (status === 201) {
       // 프로젝트 생성 성공, 홈 루트의 프로젝트 갱신처리
       dispatch(initial(false));
       // 해당 프로젝트 상세 페이지로 이동
-      navigate(`/project/${data}`);
+      navigate(`/projects/${data}`);
     }
   };
 
@@ -122,9 +120,6 @@ function Upload() {
         return;
       case 'description':
         setInputDescription(value);
-        return;
-      case 'sourceCode':
-        setInputSourceCode(value);
         return;
       default:
         break;
@@ -233,15 +228,6 @@ function Upload() {
                   value={inputDescription}
                   onChange={onChange}
                   placeholder="본문"
-                />
-              </label>
-              <label>
-                <input
-                  name="sourceCode"
-                  type="url"
-                  value={inputSourceCode}
-                  onChange={onChange}
-                  placeholder="소스코드 주소"
                 />
               </label>
               <button type="submit">업로드</button>

--- a/client/src/styles/config/css/Loading.module.css
+++ b/client/src/styles/config/css/Loading.module.css
@@ -1,0 +1,18 @@
+.background {
+  position: relative;
+  width: 100vw;
+  height: calc(100vh - 160px);
+  top: 0;
+  left: 0;
+  background: rgba(255, 255, 255, 0.7176470588);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading {
+  font: 1rem "Noto Sans KR";
+  text-align: center;
+}

--- a/client/src/styles/config/css/statusStyle.module.css
+++ b/client/src/styles/config/css/statusStyle.module.css
@@ -1,0 +1,26 @@
+@keyframes error {
+  from {
+    transform: translate(-50%, 0);
+  }
+  90% {
+    transform: translate(-50%, 120px);
+  }
+  to {
+    transform: translate(-50%, 120px);
+  }
+}
+.error {
+  position: absolute;
+  top: -80px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 350px;
+  height: 80px;
+  display: grid;
+  place-items: center;
+  background-color: rgba(255, 0, 0, 0.4);
+  border-radius: 30px;
+  font-size: 22px;
+  animation: error 1.5s ease-out alternate;
+  animation-iteration-count: 3;
+}

--- a/client/src/styles/global/css/App.css
+++ b/client/src/styles/global/css/App.css
@@ -1,0 +1,16 @@
+* {
+  font-family: "Noto Sans-KR", sans-serif;
+}
+
+main {
+  padding: 0 30px;
+}
+main > article {
+  min-height: calc(100vh - 80px);
+  position: relative;
+  padding: 30px 0;
+}
+main .part {
+  position: absolute;
+  transform: translateY(-80px);
+}

--- a/client/src/styles/global/css/App.css
+++ b/client/src/styles/global/css/App.css
@@ -6,7 +6,7 @@ main {
   padding: 0 30px;
 }
 main > article {
-  min-height: calc(100vh - 80px);
+  min-height: calc(100vh - 160px);
   position: relative;
   padding: 30px 0;
 }

--- a/client/src/styles/global/scss/App.scss
+++ b/client/src/styles/global/scss/App.scss
@@ -9,7 +9,7 @@ main {
 
   // 컴포넌트
   > article {
-    min-height: calc(100vh - $headerHeight);
+    min-height: calc(100vh - $headerHeight * 2);
     position: relative;
     padding: 30px 0;
   }

--- a/client/src/styles/mixins/css/Projects.module.css
+++ b/client/src/styles/mixins/css/Projects.module.css
@@ -1,0 +1,110 @@
+.hidden {
+  opacity: 0;
+}
+
+.project {
+  background-color: #eee;
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 30px;
+  position: relative;
+}
+.project button > img {
+  width: 30px;
+  height: 30px;
+}
+.project .edit {
+  position: absolute;
+  right: 30px;
+  z-index: 15;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 20px;
+}
+.project .date {
+  top: 0;
+  font-size: 14px;
+  position: absolute;
+  transform: translateY(50%);
+}
+.project .title {
+  font-size: 24px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.project .title:hover {
+  text-decoration: underline;
+}
+.project .developer {
+  display: flex;
+  float: left;
+  position: absolute;
+  left: 30px;
+}
+.project .developer .devImg {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+.project .imgWrap {
+  margin: 10px 0;
+}
+.project .imgWrap .img {
+  width: 500px;
+  height: 200px;
+  margin: 0 auto;
+  border-radius: 10px;
+  -o-object-fit: contain;
+     object-fit: contain;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+.project .form {
+  display: flex;
+  flex-wrap: wrap;
+  position: absolute;
+  width: calc(100% - 60px);
+  z-index: 10;
+}
+.project .form input {
+  background-color: transparent;
+  border: none;
+}
+.project .form .date {
+  top: 0;
+  font-size: 14px;
+  transform: translateY(-90%);
+}
+.project .form .title {
+  margin: 0 auto;
+  font-weight: bold;
+}
+.project .form .imgWrap {
+  width: 100%;
+  text-align: center;
+}
+.project .form .imgWrap input[type=file] {
+  position: absolute;
+  width: 0;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+}
+.project .form .imgWrap img {
+  cursor: pointer;
+}
+.project .form .submit {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
+
+.language {
+  display: flex;
+  gap: 5px;
+}
+.language > img {
+  width: 30px;
+  height: 30px;
+}

--- a/client/src/styles/mixins/css/Projects.module.css
+++ b/client/src/styles/mixins/css/Projects.module.css
@@ -93,6 +93,9 @@
 }
 .project .form .imgWrap img {
   cursor: pointer;
+  width: 500px;
+  height: 200px;
+  margin: 0 auto;
 }
 .project .form .submit {
   position: absolute;

--- a/client/src/styles/mixins/scss/Projects.module.scss
+++ b/client/src/styles/mixins/scss/Projects.module.scss
@@ -129,6 +129,9 @@ $padding: 30px;
       // & (폼)이미지
       img {
         cursor: pointer;
+        width: 500px;
+        height: 200px;
+        margin: 0 auto;
       }
     }
 

--- a/client/src/styles/partials/css/Footer.module.css
+++ b/client/src/styles/partials/css/Footer.module.css
@@ -1,0 +1,29 @@
+footer {
+  background-color: #000;
+  position: relative;
+  bottom: 0;
+  width: 100%;
+  height: 80px;
+}
+
+.center {
+  max-width: 1200px;
+  margin: 0 auto;
+  color: #fff;
+  padding: 15px 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 20px;
+}
+.center > h2.flex {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: normal;
+}
+
+.logo {
+  width: 40px;
+}

--- a/client/src/styles/partials/css/Header.module.css
+++ b/client/src/styles/partials/css/Header.module.css
@@ -1,0 +1,59 @@
+.header {
+  z-index: 1000;
+  background-color: #000;
+  width: 100%;
+  height: 80px;
+  position: sticky;
+  top: 0;
+  left: 0;
+  box-shadow: 0 0 10px 10px #ccc;
+}
+.header .center {
+  margin: 0 auto;
+  max-width: 1200px;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
+  padding: 0 10px;
+}
+@media screen and (max-width: 743px) {
+  .header .center {
+    padding: 0 20px;
+  }
+}
+.header .center .picture {
+  display: flex;
+  align-items: center;
+  height: 80px;
+}
+.header .center .ul {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+}
+.header .center .ul li {
+  position: relative;
+}
+.header .center .ul li::after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 1px;
+  bottom: 0;
+  left: 50%;
+  margin: 0 auto;
+  transform: translate(-50%, 7px);
+  transform-origin: center;
+  background-color: #fff;
+  transition: 0.5s;
+}
+.header .center .ul li:hover::after {
+  width: 100%;
+}
+.header .center .btn {
+  display: flex;
+  gap: 10px;
+}

--- a/client/src/styles/partials/css/Page.module.css
+++ b/client/src/styles/partials/css/Page.module.css
@@ -1,0 +1,56 @@
+.article {
+  display: grid;
+  place-content: center;
+  text-align: center;
+  font-size: 24px;
+}
+
+.title {
+  position: relative;
+  text-align: center;
+  font-size: 36px;
+  text-shadow: 4px 4px 0 rgba(0, 0, 0, 0.2);
+  margin-bottom: 20px;
+}
+
+.language {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 20px;
+}
+.language img {
+  display: block;
+  width: 30px;
+  height: 30px;
+  margin: 0 auto;
+}
+.language span {
+  display: block;
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.scrollBtn {
+  display: block;
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  right: 50%;
+  bottom: 50px;
+  transform: translate(-50%, -50%);
+  border-bottom: 1px solid #000;
+  border-right: 1px solid #000;
+  rotate: 45deg;
+  animation: btnAni 1s ease-out alternate infinite;
+}
+
+@keyframes btnAni {
+  from {
+    transform: translate(-50%, -50%);
+  }
+  to {
+    transform: translate(-150%, -150%);
+  }
+}

--- a/client/src/styles/partials/css/Projects.module.css
+++ b/client/src/styles/partials/css/Projects.module.css
@@ -1,0 +1,5 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}

--- a/client/src/styles/screen/css/DetailProject.module.css
+++ b/client/src/styles/screen/css/DetailProject.module.css
@@ -93,7 +93,7 @@
 .logoImg {
   width: 50px;
   height: 50px;
-  margin-bottom: 5px;
+  margin: 0 auto 5px;
 }
 .logoImg + p {
   font-size: 12px;

--- a/client/src/styles/screen/css/DetailProject.module.css
+++ b/client/src/styles/screen/css/DetailProject.module.css
@@ -1,0 +1,121 @@
+.article {
+  display: grid;
+  place-content: center;
+  gap: 20px;
+}
+
+.aside {
+  position: fixed;
+  left: 50px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.aside > ul li {
+  margin: 10px 0;
+}
+.aside > ul li:hover {
+  text-decoration: underline;
+}
+.aside > ul li a {
+  display: block;
+}
+.aside > ul li .active {
+  color: #ecdad1;
+  border-left: 5px solid #000;
+  text-indent: 10px;
+  text-shadow: 0.5px 0.5px 1px rgba(0, 0, 0, 0.5);
+}
+
+.topWrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.devImgWrap {
+  float: left;
+}
+
+.devImg {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+}
+
+.titleWrap {
+  text-align: center;
+  font-size: 24px;
+  line-height: 1;
+}
+.titleWrap > small {
+  font-size: 12px;
+}
+
+.editBtn {
+  float: right;
+}
+
+.empty {
+  width: 100px;
+}
+
+.picture {
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 50px;
+}
+.picture img {
+  max-width: 1200px;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
+.language {
+  display: flex;
+  gap: 10px;
+}
+
+.logoImg {
+  width: 50px;
+  height: 50px;
+  margin-bottom: 5px;
+}
+.logoImg + p {
+  font-size: 12px;
+  text-align: center;
+}
+
+.description {
+  font-size: 18px;
+  padding: 10px;
+}
+
+.info {
+  display: flex;
+  gap: 20px;
+}
+
+.sourceCode {
+  display: block;
+  text-indent: 40px;
+  background: url("/public/images/ico/github-icon.svg") no-repeat left/30px;
+  line-height: 2;
+}
+
+.prevBtn {
+  position: fixed;
+  top: 130px;
+  left: 50px;
+  width: 30px;
+  height: 30px;
+}
+.prevBtn::after {
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-top: 2px solid #000;
+  border-left: 2px solid #000;
+  rotate: -45deg;
+  transform: translate(50%, 50%);
+}

--- a/client/src/styles/screen/css/DetailProject.module.css
+++ b/client/src/styles/screen/css/DetailProject.module.css
@@ -61,13 +61,27 @@
 }
 
 .picture {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.05);
   border-radius: 50px;
+  margin: 10px 0;
 }
 .picture img {
   max-width: 1200px;
   -o-object-fit: cover;
      object-fit: cover;
+}
+
+.info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+}
+.info .url {
+  display: block;
+  width: 40px;
+  height: 40px;
+  background: url("/public/images/ico/github-icon.svg") no-repeat center/cover;
 }
 
 .language {
@@ -88,18 +102,6 @@
 .description {
   font-size: 18px;
   padding: 10px;
-}
-
-.info {
-  display: flex;
-  gap: 20px;
-}
-
-.sourceCode {
-  display: block;
-  text-indent: 40px;
-  background: url("/public/images/ico/github-icon.svg") no-repeat left/30px;
-  line-height: 2;
 }
 
 .prevBtn {

--- a/client/src/styles/screen/css/DetailProject.module.css
+++ b/client/src/styles/screen/css/DetailProject.module.css
@@ -67,6 +67,7 @@
 }
 .picture img {
   max-width: 1200px;
+  max-height: 675px;
   -o-object-fit: cover;
      object-fit: cover;
 }

--- a/client/src/styles/screen/css/DetailProject.module.css
+++ b/client/src/styles/screen/css/DetailProject.module.css
@@ -52,8 +52,10 @@
   font-size: 12px;
 }
 
-.editBtn {
+.edit {
   float: right;
+  display: flex;
+  gap: 20px;
 }
 
 .empty {

--- a/client/src/styles/screen/css/Join.module.css
+++ b/client/src/styles/screen/css/Join.module.css
@@ -1,0 +1,32 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  max-width: 550px;
+  gap: 10px;
+}
+.form label {
+  display: flex;
+  align-items: center;
+}
+.form label span {
+  display: inline-block;
+  width: 130px;
+}
+.form label div {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.form label div input {
+  padding: 5px 10px;
+}
+.form label input[name=pw] {
+  margin-right: 25px;
+}
+.form button {
+  margin-top: 10px;
+  text-align: center;
+  background-color: #eee;
+  padding: 20px 0;
+  border-radius: 20px;
+}

--- a/client/src/styles/screen/css/Login.module.css
+++ b/client/src/styles/screen/css/Login.module.css
@@ -1,0 +1,64 @@
+.screen {
+  height: calc(100vh - 160px);
+  position: relative;
+}
+
+.formWrap {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+.formWrap h2 {
+  text-align: center;
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+.form {
+  display: grid;
+  flex-direction: column;
+  grid-template-areas: "inputID button" "inputPW button";
+  max-width: 300px;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.form input {
+  border-radius: 10px;
+  padding: 5px 10px;
+  border-width: 0.5px;
+}
+.form input[type=text] {
+  grid-area: inputID;
+}
+.form input[type=password] {
+  grid-area: inputPW;
+}
+.form input:focus {
+  border-width: 1px;
+  background-color: #eee;
+}
+.form button {
+  border: 0.5px solid #000;
+  grid-area: button;
+  white-space: nowrap;
+  padding: 0 10px;
+  border-radius: 10px;
+}
+.form button:hover {
+  background-color: #eee;
+}
+
+.githubLogin {
+  display: block;
+  width: 100%;
+  height: 50px;
+  background: no-repeat 30px/30px;
+  background-image: url("/public/images/ico/github-icon.svg");
+  border: 2px solid #eee;
+  border-radius: 20px;
+  text-align: center;
+}
+.githubLogin:hover {
+  text-decoration: underline;
+}

--- a/client/src/styles/screen/css/Project.module.css
+++ b/client/src/styles/screen/css/Project.module.css
@@ -1,0 +1,131 @@
+.project {
+  background-color: #ffede6;
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 30px;
+  position: relative;
+}
+.project button > img {
+  width: 30px;
+  height: 30px;
+}
+.project .edit {
+  position: absolute;
+  right: 30px;
+  z-index: 15;
+  display: flex;
+  gap: 20px;
+}
+.project .title {
+  font-size: 24px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.project .member {
+  display: flex;
+  float: left;
+  position: absolute;
+  left: 30px;
+}
+.project .img {
+  width: 400px;
+  height: 300px;
+  margin: 0 auto;
+  border-radius: 10px;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+.project .hidden {
+  opacity: 0;
+}
+.project .deleteCheck {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(255, 255, 255, 0.5);
+  width: 300px;
+  height: 200px;
+  z-index: 20;
+}
+.project .form {
+  display: flex;
+  flex-wrap: wrap;
+  position: absolute;
+  width: calc(100% - 60px);
+  z-index: 10;
+}
+.project .form input {
+  background-color: transparent;
+  border: none;
+}
+.project .form .member {
+  left: 0;
+}
+.project .form .title {
+  margin: 0 auto;
+  font-weight: bold;
+}
+.project .form .imgWrap {
+  width: 100%;
+  text-align: center;
+}
+.project .form .imgWrap input[name=img] {
+  position: absolute;
+  left: 25%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+.project .form .submit {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
+
+.language {
+  display: flex;
+  gap: 5px;
+}
+.language > i {
+  display: block;
+  width: 30px;
+  height: 30px;
+  background: no-repeat center/cover;
+}
+.language [class=HTML] {
+  background-image: url("/public/images/ico/html-icon.svg");
+}
+.language [class=CSS] {
+  background-image: url("/public/images/ico/css-icon.svg");
+}
+.language [class=JS] {
+  background-image: url("/public/images/ico/js-icon.svg");
+}
+.language [class=REACT] {
+  background-image: url("/public/images/ico/reactjs-icon.svg");
+}
+.language [class=EXPRESS] {
+  background-image: url("/public/images/ico/expressjs-icon.svg");
+}
+.language [class=NODE] {
+  background-image: url("/public/images/ico/nodejs-icon.svg");
+}
+.language [class=MONGODB] {
+  background-image: url("/public/images/ico/mongodb-icon.svg");
+}
+
+.langIcon {
+  background: no-repeat center/cover;
+  background-color: skyblue;
+}
+
+.CSS {
+  font-size: 24px;
+}
+
+.react {
+  width: 50px;
+  height: 50px;
+  background-color: skyblue;
+}

--- a/client/src/styles/screen/css/Upload.module.css
+++ b/client/src/styles/screen/css/Upload.module.css
@@ -1,0 +1,64 @@
+.article {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.form {
+  display: grid;
+  justify-content: center;
+  gap: 15px;
+}
+.form label {
+  overflow: hidden;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.form label .name {
+  width: 50px;
+}
+.form label input {
+  border: none;
+  border-bottom: 1px solid #ddd;
+  width: 100%;
+}
+.form label input[type=file] {
+  width: 80px;
+  overflow: hidden;
+}
+.form label .select ul {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.form label .select ul > li {
+  position: relative;
+  cursor: pointer;
+}
+.form label .select ul > li .check {
+  display: block;
+  width: 15px;
+  height: 15px;
+  background: no-repeat center/cover;
+  background-image: url("/public/images/ico/check.svg");
+  position: absolute;
+  right: 0;
+}
+.form label .select ul > li img {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+}
+.form label textarea {
+  all: unset;
+  width: 100%;
+  height: 200px;
+  border: 1px solid #eee;
+  padding: 10px;
+}
+.form img {
+  margin: 0 auto;
+  max-width: 400px;
+  max-height: 300px;
+}

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -66,8 +66,10 @@
 }
 
 // 수정하기 버튼
-.editBtn {
+.edit {
   float: right;
+  display: flex;
+  gap: 20px;
 }
 // 비로그인시 차지 영역
 .empty {

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -81,6 +81,7 @@
   margin: 10px 0;
   img {
     max-width: 1200px;
+    max-height: 675px;
     object-fit: cover;
   }
 }

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -102,7 +102,7 @@
   }
 }
 
-// 프로그램 언어 및 도구
+// ^ 프로그램 언어 및 도구
 .language {
   display: flex;
   gap: 10px;
@@ -110,7 +110,7 @@
 .logoImg {
   width: 50px;
   height: 50px;
-  margin-bottom: 5px;
+  margin: 0 auto 5px;
   & + p {
     font-size: 12px;
     text-align: center;

--- a/client/src/styles/screen/scss/DetailProject.module.scss
+++ b/client/src/styles/screen/scss/DetailProject.module.scss
@@ -76,11 +76,28 @@
 
 // ^ 프로젝트 이미지
 .picture {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.05);
   border-radius: 50px;
+  margin: 10px 0;
   img {
     max-width: 1200px;
     object-fit: cover;
+  }
+}
+// ^ 소스코드
+.info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+
+  // 소스코드
+  .url {
+    display: block;
+    width: 40px;
+    height: 40px;
+    background: url('/public/images/ico/github-icon.svg') no-repeat center /
+      cover;
   }
 }
 
@@ -103,20 +120,6 @@
 .description {
   font-size: 18px;
   padding: 10px;
-}
-
-// ^ 소스코드, API 등등
-.info {
-  display: flex;
-  gap: 20px;
-}
-
-// ^ 소스코드
-.sourceCode {
-  display: block;
-  text-indent: 40px;
-  background: url('/public/images/ico/github-icon.svg') no-repeat left / 30px;
-  line-height: 2;
 }
 
 // * 이전 페이지로 이동

--- a/client/src/view/css/Footer.module.css
+++ b/client/src/view/css/Footer.module.css
@@ -1,0 +1,28 @@
+footer {
+  background-color: #000;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 120px;
+}
+
+.center {
+  max-width: 1200px;
+  margin: 0 auto;
+  color: #fff;
+  padding: 15px 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+.center > h2.flex {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: normal;
+}
+
+.logo {
+  width: 40px;
+}

--- a/client/src/view/css/Header.module.css
+++ b/client/src/view/css/Header.module.css
@@ -1,0 +1,68 @@
+header {
+  background-color: #000;
+  width: 100%;
+  height: 80px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  box-shadow: 0 0 10px 10px #ccc;
+}
+header .center {
+  margin: 0 auto;
+  max-width: 1200px;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
+  padding: 0 10px;
+}
+@media screen and (max-width: 743px) {
+  header .center {
+    padding: 0 20px;
+  }
+}
+header .center picture {
+  display: flex;
+  align-items: center;
+  height: 80px;
+}
+header .center nav > ul {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+}
+header .center nav > ul li {
+  position: relative;
+}
+header .center nav > ul li::after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 1px;
+  bottom: 0;
+  left: 50%;
+  margin: 0 auto;
+  transform: translate(-50%, 7px);
+  transform-origin: center;
+  background-color: #fff;
+  transition: 0.5s;
+}
+header .center nav > ul li:hover::after {
+  width: 100%;
+}
+header .center button {
+  padding: 5px 10px;
+  border: 1px solid trasnparent;
+  border-radius: 10px;
+  background-color: #fff;
+  color: #000;
+  transition: 0.3s;
+  box-shadow: 0 0 10px 3px #fff;
+}
+header .center button:hover {
+  background-color: #000;
+  color: #fff;
+  border: 1px solid #fff;
+}

--- a/client/src/view/css/Join.module.css
+++ b/client/src/view/css/Join.module.css
@@ -1,0 +1,32 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  max-width: 550px;
+  gap: 10px;
+}
+.form label {
+  display: flex;
+  align-items: center;
+}
+.form label span {
+  display: inline-block;
+  width: 130px;
+}
+.form label div {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.form label div input {
+  padding: 5px 10px;
+}
+.form label input[name=pw] {
+  margin-right: 25px;
+}
+.form button {
+  margin-top: 10px;
+  text-align: center;
+  background-color: #eee;
+  padding: 20px 0;
+  border-radius: 20px;
+}

--- a/client/src/view/css/Login.module.css
+++ b/client/src/view/css/Login.module.css
@@ -1,0 +1,37 @@
+.main {
+  margin-top: 80px;
+  padding: 30px;
+}
+
+.form {
+  display: grid;
+  flex-direction: column;
+  grid-template-areas: "inputID button" "inputPW button";
+  max-width: 230px;
+  gap: 10px;
+}
+.form input {
+  border-radius: 10px;
+  padding: 5px 10px;
+  border-width: 0.5px;
+}
+.form input[type=text] {
+  grid-area: inputID;
+}
+.form input[type=password] {
+  grid-area: inputPW;
+}
+.form input:focus {
+  border-width: 1px;
+  background-color: #eee;
+}
+.form button {
+  border: 0.5px solid #000;
+  grid-area: button;
+  white-space: nowrap;
+  padding: 0 10px;
+  border-radius: 10px;
+}
+.form button:hover {
+  background-color: #eee;
+}

--- a/server/controllers/apiController.js
+++ b/server/controllers/apiController.js
@@ -149,8 +149,7 @@ export const postProjectEdit = async (req, res) => {
 // 프로젝트 삭제
 export const postProjectDelete = async (req, res) => {
   const {
-    params: { id },
-    body: { thumbnail },
+    params: { id, thumbnail },
   } = req;
   try {
     const project = await Project.findByIdAndDelete(id);

--- a/server/models/Project.js
+++ b/server/models/Project.js
@@ -9,7 +9,6 @@ const projectSchema = new mongoose.Schema({
   thumbnail: { type: String, required: true },
   language: [{ type: String, required: true }],
   description: { type: String, required: true },
-  sourceCode: { type: String, required: true },
 });
 
 const Project = mongoose.model('Project', projectSchema);

--- a/server/router/apiRouter.js
+++ b/server/router/apiRouter.js
@@ -34,7 +34,7 @@ apiRouter.put(
   postProjectEdit
 );
 apiRouter.delete('/projects/:id/:thumbnail', postProjectDelete);
-apiRouter.get('/avatarImg', getAvatarImg);
+apiRouter.get('/avatarimg', getAvatarImg);
 // apiRouter.get('/image/:id', getImage);
 
 export default apiRouter;

--- a/server/router/apiRouter.js
+++ b/server/router/apiRouter.js
@@ -28,12 +28,12 @@ apiRouter.post('/login/github/access', postLoginGithub);
 apiRouter.route('/join').post(postJoin);
 apiRouter.post('/upload', projectImg.single('thumbnail'), postUpload);
 apiRouter.get('/project/:id', getProject);
-apiRouter.post(
+apiRouter.put(
   '/project/:id/edit',
   projectImg.single('thumbnail'),
   postProjectEdit
 );
-apiRouter.post('/project/:id/delete', postProjectDelete);
+apiRouter.delete('/project/:id/:thumbnail', postProjectDelete);
 apiRouter.get('/avatarImg', getAvatarImg);
 // apiRouter.get('/image/:id', getImage);
 

--- a/server/router/apiRouter.js
+++ b/server/router/apiRouter.js
@@ -27,13 +27,13 @@ apiRouter.get('/login/github/token', tokenLoginGithub);
 apiRouter.post('/login/github/access', postLoginGithub);
 apiRouter.route('/join').post(postJoin);
 apiRouter.post('/upload', projectImg.single('thumbnail'), postUpload);
-apiRouter.get('/project/:id', getProject);
+apiRouter.get('/projects/:id', getProject);
 apiRouter.put(
-  '/project/:id/edit',
+  '/projects/:id/edit',
   projectImg.single('thumbnail'),
   postProjectEdit
 );
-apiRouter.delete('/project/:id/:thumbnail', postProjectDelete);
+apiRouter.delete('/projects/:id/:thumbnail', postProjectDelete);
 apiRouter.get('/avatarImg', getAvatarImg);
 // apiRouter.get('/image/:id', getImage);
 


### PR DESCRIPTION
1. 변환된 CSS 파일도 업로드
2. `Project` 의 `SourceCode` 가 `Url` 을 대체하기로 함 `SourceCode` &rarr;` Url` 그로인해 기존의 url은 제거
3. 상세 프로젝트에서 소스코드가 URL로 이동함에 따라서 해당 위치를 미리보기 이미지 위치로 수정
4. `홈 컴포넌트` 프로젝트 수정 시 이미지 크기 500x200 지정
5.  이전 페이지 이동에서 홈 컴포넌트 페이지로 이동으로 변경 `naviagte(-2)` &rarr; `navigate('/')`
6. **REST API 규칙**에 맞게 `axios` 요청 수정
7. 중복 호출 코드 제거